### PR TITLE
Fix a poorly placed comment

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,14 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source//{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: a6fe125091792d16c962cc3720c950c2b87fcc8c3ecf0c54c84e9a20b814526c
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-  skip: true # [py<37 or s390x] # no ypy-websocket on s390x (ends up depending on missing rust tools)
+  # no ypy-websocket on s390x (ends up depending on missing rust tools)
+  skip: true # [py<37 or s390x]
 
 requirements:
   host:


### PR DESCRIPTION
That caused all architectures to be skipped. 
Also fix a typo that slipped in during a rebase conflict; it was hidden by the skip.