### PR TITLE
Turn on tests and update build num

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 # there is a test dependency on jupyter_server, but jupyter_server has
 # a runtime dependency on this package. Build first with true, then
 # after jupyter_server is available bump build number and rebuild with false.
-{% set break_cycle = true %}
+{% set break_cycle = false %}
 
 package:
   name: {{ name|lower }}
@@ -14,7 +14,7 @@ source:
   sha256: a6fe125091792d16c962cc3720c950c2b87fcc8c3ecf0c54c84e9a20b814526c
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   # no ypy-websocket on s390x (ends up depending on missing rust tools)
   skip: true # [py<37 or s390x]


### PR DESCRIPTION
This is a followup commit to build with tests enabled; we had to do this to break a dependency cycle with jupyter-server.