### PR TITLE
jupyter_server_ydoc 2.3.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - jupyter_server >=2.15.0,<3.0.0
-    - jupyter_ydoc >=3.0.3,<4.0.0
+    - jupyter_ydoc >=3.4.0,<4.0.0
     - pycrdt
     - pycrdt-websocket >=0.16.0,<0.17.0
     - jupyter_events >=0.11.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_server_ydoc" %}
-{% set version = "2.2.0" %}
+{% set version = "2.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bc6c3e3775c6f45fe10c4831f206aeb80df4348eb11f1b7a6c1c320aa0eac340
+  sha256: 36f311491e9f289f461fcdf26afb9b72cdf0eac3ceed0c0cbc8ec43afc8efebc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<38]
+  skip: true  # [py<310]
 
 requirements:
   host:


### PR DESCRIPTION
jupyter_server_ydoc 2.3.0 

**Destination channel:** Defaults

### Links

- [PKG-14574]
- dev_url:        https://github.com/jupyterlab/jupyter-collaboration/tree/v4.3.0
- conda_forge:    https://github.com/conda-forge/jupyter_server_ydoc-feedstock
- pypi:           https://pypi.org/project/jupyter_server_ydoc/2.3.0
- pypi inspector: https://inspector.pypi.io/project/jupyter_server_ydoc/2.3.0

### Explanation of changes:

- new version number


[PKG-14574]: https://anaconda.atlassian.net/browse/PKG-14574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ